### PR TITLE
fix: document GitHub Actions permissions requirement for release workflow

### DIFF
--- a/.changeset/fix-release-permissions.md
+++ b/.changeset/fix-release-permissions.md
@@ -1,0 +1,14 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: document GitHub Actions permissions requirement for release workflow
+
+- Add clear documentation about required repository settings
+- Add comments in release workflow about permissions requirement
+- Add issues write permission for better GitHub integration
+- Update README, CONTRIBUTING, and CLAUDE documentation
+
+This fixes the release workflow failure by documenting that repository
+administrators must enable "Allow GitHub Actions to create and approve
+pull requests" in Settings → Actions → General.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,10 +7,13 @@ on:
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
+# Note: For this workflow to create PRs, you must enable "Allow GitHub Actions
+# to create and approve pull requests" in Settings > Actions > General
 permissions:
   contents: write
   pull-requests: write
   id-token: write
+  issues: write
 
 jobs:
   release:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - **Pre-commit hooks** via Husky run lint-staged (Prettier and ESLint)
 - **Attestations**: SLSA provenance and SBOM attestations for build artifacts
 - **Trunk-based development** with branch protection and linear history
+- **Release automation**: Requires "Allow GitHub Actions to create and approve pull requests" setting
 
 ### Development Process
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -267,6 +267,16 @@ Releases are automated:
 3. When release PR is merged, packages are versioned and published
 4. Changelog is automatically updated
 
+### ⚠️ Important: Repository Configuration
+
+For maintainers, ensure the following repository setting is enabled:
+
+1. Go to **Settings** → **Actions** → **General**
+2. Under "Workflow permissions", check:
+   - ✅ **"Allow GitHub Actions to create and approve pull requests"**
+
+This is required for the automated release workflow to create version PRs.
+
 ## 💡 Tips
 
 - Keep PRs focused and small

--- a/README.md
+++ b/README.md
@@ -135,6 +135,16 @@ pnpm changeset  # For user-facing changes
 pnpm changeset --empty  # For internal changes (no release)
 ```
 
+### ⚠️ Required Repository Settings
+
+For the release automation to work, you must enable GitHub Actions to create pull requests:
+
+1. Go to **Settings** → **Actions** → **General**
+2. Under "Workflow permissions", enable:
+   - **"Allow GitHub Actions to create and approve pull requests"**
+
+Without this setting, the release workflow will fail with a permissions error.
+
 ## 🔒 Security Features
 
 - **Dependency Auditing**: Critical vulnerability checks on every CI run


### PR DESCRIPTION
## Summary

This PR fixes the release workflow failure by documenting the required GitHub repository settings for the automated release process to work.

## Problem

The release workflow failed with:
```
HttpError: GitHub Actions is not permitted to create or approve pull requests
```

This happens when the repository doesn't have the correct permissions enabled for GitHub Actions.

## Solution

### 📚 Documentation Added

1. **Release Workflow** (`.github/workflows/release.yml`)
   - Added comment explaining the required repository setting
   - Added `issues: write` permission for better GitHub integration

2. **README.md**
   - Added "Required Repository Settings" section under Versioning & Releases
   - Clear instructions for enabling the required permission

3. **CONTRIBUTING.md**
   - Added section for maintainers about repository configuration
   - Step-by-step guide to enable the setting

4. **CLAUDE.md**
   - Added note about release automation requirements

## Required Action for Repository Admins

To fix the release workflow, repository administrators must:

1. Go to **Settings** → **Actions** → **General**
2. Under "Workflow permissions", enable:
   - ✅ **"Allow GitHub Actions to create and approve pull requests"**

## Testing

- Documentation is clear and accurate
- Changeset included for tracking this fix
- All CI checks pass

## Changeset

Includes a patch changeset documenting this fix.

🤖 Generated with [Claude Code](https://claude.ai/code)