### PR TITLE
feat: update release workflow with modern GitHub Release action and conditional NPM publishing

### DIFF
--- a/.changeset/update-release-workflow.md
+++ b/.changeset/update-release-workflow.md
@@ -1,0 +1,10 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+feat: update release workflow with modern GitHub Release action and conditional NPM publishing
+
+- Replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
+- Add conditional NPM publishing that only runs when NPM_TOKEN is configured
+- Add informative logging when NPM publishing is skipped
+- Maintain backward compatibility with existing release process

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,15 +54,29 @@ jobs:
           # Uncomment below if you want to publish to npm
           # NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      # Optional: Create GitHub Release when changesets are published
+      # Conditional NPM Publishing
+      - name: Publish to NPM
+        if: steps.changesets.outputs.published == 'true' && env.NPM_TOKEN != ''
+        run: |
+          echo "Publishing to NPM..."
+          npm config set //registry.npmjs.org/:_authToken ${{ secrets.NPM_TOKEN }}
+          pnpm publish --no-git-checks
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Log NPM Publishing Skipped
+        if: steps.changesets.outputs.published == 'true' && env.NPM_TOKEN == ''
+        run: |
+          echo "📦 NPM publishing skipped - NPM_TOKEN not configured"
+          echo "To enable NPM publishing, add NPM_TOKEN to repository secrets"
+
+      # Create GitHub Release using newer action
       - name: Create GitHub Release
         if: steps.changesets.outputs.published == 'true'
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}
-          release_name: Release v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}
+          name: Release v${{ fromJson(steps.changesets.outputs.publishedPackages)[0].version }}
           body: |
             ## What's Changed
             See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.


### PR DESCRIPTION
## Summary
- Replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v2`
- Add conditional NPM publishing that only runs when NPM_TOKEN is configured
- Add informative logging when NPM publishing is skipped

## Changes
1. **Updated GitHub Release action**: Migrated from deprecated `actions/create-release@v1` to the actively maintained `softprops/action-gh-release@v2`
2. **Conditional NPM publishing**: Added logic to check for NPM_TOKEN and only publish to npm when it's configured
3. **Logging for skipped NPM publish**: When NPM_TOKEN is not configured, logs a helpful message explaining how to enable npm publishing

## Test Plan
- [ ] CI checks pass
- [ ] Release workflow runs successfully when merged
- [ ] NPM publishing is skipped with log message when NPM_TOKEN is not set
- [ ] NPM publishing runs when NPM_TOKEN is configured (future test)

🤖 Generated with [Claude Code](https://claude.ai/code)