### PR TITLE
fix: correct ncipollo/release-action version from v2 to v1

### DIFF
--- a/.changeset/fix-release-action-version.md
+++ b/.changeset/fix-release-action-version.md
@@ -1,0 +1,7 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: correct ncipollo/release-action version from v2 to v1
+
+The action version v2 doesn't exist. Use v1 which is the current major version tag that points to the latest stable release (v1.18.0).

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,7 +109,7 @@ jobs:
       # Create GitHub Release with SBOM
       - name: Create GitHub Release
         if: steps.version_check.outputs.changed == 'true'
-        uses: ncipollo/release-action@v2
+        uses: ncipollo/release-action@v1
         with:
           tag: ${{ steps.create_tag.outputs.tag }}
           name: Release ${{ steps.create_tag.outputs.tag }}


### PR DESCRIPTION
## Problem
The release workflow was failing with:
```
Unable to resolve action ncipollo/release-action@v2, unable to find version v2
```

## Solution
Changed from `ncipollo/release-action@v2` to `ncipollo/release-action@v1`

The action uses v1 as the major version tag, which currently points to v1.18.0 (latest stable release).

## Test Plan
- [x] CI checks pass
- [ ] When merged, release workflow will run successfully
- [ ] Version PR will be created with the fix

🤖 Generated with [Claude Code](https://claude.ai/code)