### PR TITLE
fix: add attestations write permission to release workflow

### DIFF
--- a/.changeset/fix-attestations-permission.md
+++ b/.changeset/fix-attestations-permission.md
@@ -1,0 +1,7 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: add attestations write permission to release workflow
+
+The release workflow was failing with "Resource not accessible by integration" when trying to create attestations. Added the missing `attestations: write` permission.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ permissions:
   pull-requests: write
   id-token: write
   issues: write
+  attestations: write
 
 jobs:
   release:


### PR DESCRIPTION
## Problem
The release workflow failed with:
```
Error: Failed to persist attestation: Resource not accessible by integration
```

This occurred when the workflow tried to create build provenance attestations.

## Solution
Added the missing `attestations: write` permission to the release workflow.

## Test Plan
- [x] CI checks pass
- [ ] When merged, release workflow will have proper permissions
- [ ] Attestations will be created successfully

🤖 Generated with [Claude Code](https://claude.ai/code)