### PR TITLE
fix: update auto-merge workflow to recognize changesets PR author

### DIFF
--- a/.changeset/fix-auto-merge-actor.md
+++ b/.changeset/fix-auto-merge-actor.md
@@ -1,0 +1,7 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: update auto-merge workflow to recognize changesets PR author
+
+The auto-merge workflow was checking for `github-actions[bot]` but changesets creates PRs with `app/github-actions` as the author. Updated the condition to check for both formats.

--- a/.github/workflows/auto-merge-version-pr.yml
+++ b/.github/workflows/auto-merge-version-pr.yml
@@ -8,8 +8,8 @@ jobs:
   auto-merge:
     name: Enable Auto-Merge for Version PRs
     runs-on: ubuntu-latest
-    # Only run for PRs created by github-actions bot
-    if: github.actor == 'github-actions[bot]' && !github.event.pull_request.draft
+    # Only run for PRs created by github-actions bot or app
+    if: (github.actor == 'github-actions[bot]' || github.actor == 'app/github-actions') && !github.event.pull_request.draft
 
     steps:
       - name: Check PR Title


### PR DESCRIPTION
## Summary
- Fixed auto-merge workflow condition to recognize PRs created by changesets
- The workflow was checking for `github-actions[bot]` but changesets creates PRs with `app/github-actions` as the author
- Updated the condition to check for both formats

## Context
PR #17 (version packages PR) was not getting auto-merge enabled because the actor check was failing. This fix will allow auto-merge to work for changesets PRs.

## Test Plan
Once merged, the next version PR created by changesets should have auto-merge enabled automatically.