### PR TITLE
fix: check PR title instead of actor for auto-merge workflow

### DIFF
--- a/.changeset/fix-auto-merge-pr-author.md
+++ b/.changeset/fix-auto-merge-pr-author.md
@@ -1,0 +1,7 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: check PR title instead of actor for auto-merge workflow
+
+The auto-merge workflow was checking `github.actor` which is the user who triggers the workflow (including when pushing updates to the PR), not the PR author. Changed to check the PR title directly in the job condition, which is more reliable and works regardless of who triggers the workflow.

--- a/.github/workflows/auto-merge-version-pr.yml
+++ b/.github/workflows/auto-merge-version-pr.yml
@@ -8,23 +8,13 @@ jobs:
   auto-merge:
     name: Enable Auto-Merge for Version PRs
     runs-on: ubuntu-latest
-    # Only run for PRs created by github-actions bot or app
-    if: (github.actor == 'github-actions[bot]' || github.actor == 'app/github-actions') && !github.event.pull_request.draft
+    # Only run for non-draft PRs with the specific title
+    if: |
+      github.event.pull_request.title == 'chore: version packages' && 
+      !github.event.pull_request.draft
 
     steps:
-      - name: Check PR Title
-        id: check
-        run: |
-          if [[ "${{ github.event.pull_request.title }}" == "chore: version packages" ]]; then
-            echo "is_version_pr=true" >> $GITHUB_OUTPUT
-            echo "✅ This is a version PR - will enable auto-merge"
-          else
-            echo "is_version_pr=false" >> $GITHUB_OUTPUT
-            echo "ℹ️ Not a version PR - skipping auto-merge"
-          fi
-
       - name: Enable Auto-Merge
-        if: steps.check.outputs.is_version_pr == 'true'
         run: |
           echo "Enabling auto-merge for PR #${{ github.event.pull_request.number }}"
           gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
@@ -33,7 +23,6 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Add Auto-Merge Comment
-        if: steps.check.outputs.is_version_pr == 'true'
         run: |
           gh pr comment "${{ github.event.pull_request.number }}" --body "🤖 **Auto-merge enabled**
 


### PR DESCRIPTION
## Summary
- Fixed auto-merge workflow to check PR title directly instead of checking the actor
- Simplified the workflow by removing redundant title check in steps

## Context
The previous fix didn't work because `github.actor` is whoever triggers the workflow (including when pushing updates), not the PR author. This new approach checks the PR title directly in the job condition, which is more reliable and works regardless of who triggers the workflow.

## Test Plan
Once merged, the auto-merge workflow will run for any PR with title "chore: version packages" regardless of who creates it or triggers the workflow.