### PR TITLE
fix: include actual CHANGELOG content in GitHub release body

### DIFF
--- a/.changeset/include-changelog-in-release.md
+++ b/.changeset/include-changelog-in-release.md
@@ -1,0 +1,12 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: include actual CHANGELOG content in GitHub release body
+
+- Extract changelog content for the specific version being released
+- Include the actual changes in the GitHub release body instead of just linking to CHANGELOG.md
+- Users can now see what changed directly in the GitHub release without clicking through
+- Maintains link to full CHANGELOG for historical reference
+
+This improves the user experience by showing the actual changes for each release directly in the GitHub release page.

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -240,6 +240,49 @@ jobs:
           git push origin "v$VERSION"
           echo "tag=v$VERSION" >> $GITHUB_OUTPUT
 
+      # Extract CHANGELOG content for this version
+      - name: Extract CHANGELOG Content
+        if: steps.version_check.outputs.changed == 'true'
+        id: changelog
+        run: |
+          VERSION=${{ steps.version_check.outputs.version }}
+
+          # Extract content between this version and the next version header
+          # This handles both the latest version and older versions
+          CHANGELOG_CONTENT=$(awk -v ver="## $VERSION" '
+            BEGIN { found = 0 }
+            $0 ~ ver { found = 1; next }
+            found && /^## [0-9]+\.[0-9]+\.[0-9]+/ { exit }
+            found { print }
+          ' CHANGELOG.md)
+
+          # If no content found, provide a fallback
+          if [ -z "$CHANGELOG_CONTENT" ]; then
+            CHANGELOG_CONTENT="No changelog entry found for version $VERSION"
+          fi
+
+          # Create the complete release body with changelog content
+          cat > release_body.md << EOF
+          ## Release v$VERSION
+
+          $CHANGELOG_CONTENT
+
+          ### Artifacts
+          - 📦 SBOM (CycloneDX format) attached below
+          - ✅ Build provenance attestation available
+          - ✅ SBOM attestation available
+
+          ### Distribution
+          Package distribution is handled by the release.yml workflow.
+          To enable npm publishing, Docker builds, or documentation deployment,
+          see the Release Distribution Setup section in README.md.
+
+          ---
+          See the [full CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for all releases.
+          EOF
+
+          echo "Content extracted for version $VERSION"
+
       # Create GitHub Release with artifacts
       - name: Create GitHub Release
         if: steps.version_check.outputs.changed == 'true'
@@ -247,19 +290,6 @@ jobs:
         with:
           tag: ${{ steps.create_tag.outputs.tag }}
           name: Release ${{ steps.create_tag.outputs.tag }}
-          body: |
-            ## Release ${{ steps.create_tag.outputs.tag }}
-
-            See the [CHANGELOG](https://github.com/${{ github.repository }}/blob/main/CHANGELOG.md) for details.
-
-            ### Artifacts
-            - 📦 SBOM (CycloneDX format) attached below
-            - ✅ Build provenance attestation available
-            - ✅ SBOM attestation available
-
-            ### Distribution
-            Package distribution is handled by the release.yml workflow.
-            To enable npm publishing, Docker builds, or documentation deployment,
-            see the Release Distribution Setup section in README.md.
+          bodyFile: release_body.md
           artifacts: sbom.cdx.json
           makeLatest: true


### PR DESCRIPTION
## Summary

This PR fixes the issue where GitHub releases only contain a link to the CHANGELOG instead of showing the actual changes. Now the release body will include the actual changelog content for that specific version.

## Changes

- Added a new step in `ci-cd.yml` to extract CHANGELOG content for the specific version being released
- Updated the GitHub release creation to include the extracted changelog content in the release body
- Maintained a link to the full CHANGELOG for historical reference

## Benefits

- ✨ Users can see what changed directly in the GitHub release without clicking through
- 📋 The actual changelog content is displayed prominently in the release
- 🔗 Still maintains a link to the full CHANGELOG for complete history
- 🏷️ The tagged commit continues to include the full updated CHANGELOG file

## Example

The release body will now show:
```
## Release v0.2.0

### Minor Changes

- feat: enhance release workflow with SBOM attestations...
[actual changelog content here]

### Artifacts
- 📦 SBOM (CycloneDX format) attached below
...
```

Instead of just:
```
See the [CHANGELOG](link) for details.
```

## Testing

Tested the changelog extraction logic locally to ensure it correctly:
- Extracts content for the specified version
- Handles both latest and older versions
- Provides a fallback if no content is found
- Stops at the next version header

🤖 Generated with [Claude Code](https://claude.ai/code)