### PR TITLE
fix: update auto-merge workflow to recognize app/github-actions author

### DIFF
--- a/.changeset/fix-auto-merge-author.md
+++ b/.changeset/fix-auto-merge-author.md
@@ -1,0 +1,9 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+Fix auto-merge workflow to recognize app/github-actions author
+
+- GitHub Actions can appear as 'app/github-actions' when using the default token
+- Add this as valid author for version PRs created by changesets
+- This fixes auto-merge not triggering for version PRs

--- a/.github/workflows/auto-merge-version-pr.yml
+++ b/.github/workflows/auto-merge-version-pr.yml
@@ -24,10 +24,15 @@ jobs:
 
           # Verify this is actually a version PR from changesets
           PR_AUTHOR=$(gh pr view "${PR_NUMBER}" --json author --jq '.author.login')
-          if [[ "$PR_AUTHOR" != "github-actions[bot]" ]] && [[ "$PR_AUTHOR" != "github-actions" ]] && [[ "$PR_AUTHOR" != "app/github-actions" ]]; then
-            echo "::warning::PR author is '$PR_AUTHOR', not github-actions bot. Skipping auto-merge for security."
-            exit 0
-          fi
+          case "$PR_AUTHOR" in
+            "github-actions[bot]"|"github-actions"|"app/github-actions")
+              # allowed bot authors, continue
+              ;;
+            *)
+              echo "::warning::PR author is '$PR_AUTHOR', not github-actions bot. Skipping auto-merge for security."
+              exit 0
+              ;;
+          esac
 
           gh pr merge --auto --squash "${PR_NUMBER}" || {
             echo "::warning::Could not enable auto-merge. This requires a PAT with 'repo' scope."

--- a/.github/workflows/auto-merge-version-pr.yml
+++ b/.github/workflows/auto-merge-version-pr.yml
@@ -24,8 +24,8 @@ jobs:
 
           # Verify this is actually a version PR from changesets
           PR_AUTHOR=$(gh pr view "${PR_NUMBER}" --json author --jq '.author.login')
-          if [[ "$PR_AUTHOR" != "github-actions[bot]" ]] && [[ "$PR_AUTHOR" != "github-actions" ]]; then
-            echo "::warning::PR author is not github-actions bot. Skipping auto-merge for security."
+          if [[ "$PR_AUTHOR" != "github-actions[bot]" ]] && [[ "$PR_AUTHOR" != "github-actions" ]] && [[ "$PR_AUTHOR" != "app/github-actions" ]]; then
+            echo "::warning::PR author is '$PR_AUTHOR', not github-actions bot. Skipping auto-merge for security."
             exit 0
           fi
 


### PR DESCRIPTION
## Summary

This PR fixes the auto-merge workflow not triggering for version PRs created by changesets.

## Problem

The version PR (#32) created by changesets has the author , but the auto-merge workflow was only checking for  or . This caused the workflow to skip auto-merge with a security warning.

## Solution

- Add  as a valid author for version PRs
- This is the format GitHub uses when actions use the default GITHUB_TOKEN

## Testing

After this fix is merged, the auto-merge workflow should properly trigger for version PRs and enable auto-merge (if a PAT is configured).