### PR TITLE
fix: make auto-merge workflow fail explicitly without PAT

### DIFF
--- a/.changeset/require-pat-for-auto-merge.md
+++ b/.changeset/require-pat-for-auto-merge.md
@@ -1,0 +1,11 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+Make auto-merge workflow fail explicitly when PAT is not configured
+
+- Add validation step to check for AUTO_MERGE_PAT secret
+- Fail the workflow with clear error messages when PAT is missing
+- Remove silent fallback to GITHUB_TOKEN which doesn't work
+- Update success comment to confirm auto-merge is enabled
+- This ensures proper configuration is in place before attempting auto-merge

--- a/.github/workflows/auto-merge-version-pr.yml
+++ b/.github/workflows/auto-merge-version-pr.yml
@@ -14,6 +14,21 @@ jobs:
       !github.event.pull_request.draft
 
     steps:
+      - name: Check for PAT
+        run: |
+          if [ -z "${{ secrets.AUTO_MERGE_PAT }}" ]; then
+            echo "::error::AUTO_MERGE_PAT secret is not configured."
+            echo "::error::Auto-merge requires a Personal Access Token with 'repo' scope."
+            echo "::error::Please follow the setup instructions in README.md"
+            echo ""
+            echo "To set up AUTO_MERGE_PAT:"
+            echo "1. Go to https://github.com/settings/tokens/new"
+            echo "2. Create a token with 'repo' scope"
+            echo "3. Add it as a secret named AUTO_MERGE_PAT in repository settings"
+            exit 1
+          fi
+          echo "✅ AUTO_MERGE_PAT is configured"
+
       - name: Enable Auto-Merge
         # Note: This requires a PAT with repo scope or GitHub App token
         # The default GITHUB_TOKEN cannot enable auto-merge
@@ -35,31 +50,28 @@ jobs:
           esac
 
           gh pr merge --auto --squash "${PR_NUMBER}" || {
-            echo "::warning::Could not enable auto-merge. This requires a PAT with 'repo' scope."
-            echo "::warning::See README.md for instructions on setting up auto-merge."
-            exit 0
+            echo "::error::Failed to enable auto-merge for PR #${PR_NUMBER}"
+            echo "::error::This usually means the PAT doesn't have the required permissions."
+            echo "::error::Ensure AUTO_MERGE_PAT has 'repo' scope."
+            exit 1
           }
         env:
-          # Use PAT if available, fallback to GITHUB_TOKEN (which will fail but not break the workflow)
-          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT || secrets.GITHUB_TOKEN }}
+          # Use PAT (required for auto-merge to work)
+          GH_TOKEN: ${{ secrets.AUTO_MERGE_PAT }}
           GH_REPO: ${{ github.repository }}
 
       - name: Add Auto-Merge Comment
         if: success()
         run: |
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          gh pr comment "${PR_NUMBER}" --body "🤖 **Auto-merge status**
+          gh pr comment "${PR_NUMBER}" --body "🤖 **Auto-merge enabled successfully!**
 
           This version PR will be automatically merged once all required status checks pass.
-
-          If auto-merge was not enabled (due to missing PAT), you can:
-          - Manually enable it: \`gh pr merge --auto --squash ${PR_NUMBER}\`
-          - Or merge manually once checks pass: \`gh pr merge --squash ${PR_NUMBER}\`
 
           To make changes before release:
           1. Disable auto-merge: \`gh pr merge --disable-auto ${PR_NUMBER}\`
           2. Make your changes
-          3. Re-enable auto-merge or merge manually
+          3. Re-enable auto-merge: \`gh pr merge --auto --squash ${PR_NUMBER}\`
 
           _See [README](../blob/main/README.md#automated-release-process) for details._"
         env:


### PR DESCRIPTION
## Summary

This PR makes the auto-merge workflow fail explicitly when the PAT is not configured, rather than silently falling back to a non-working state.

## Problem

The current workflow falls back to GITHUB_TOKEN when AUTO_MERGE_PAT is not configured, but GITHUB_TOKEN cannot enable auto-merge. This results in:
- Silent failures that look like successes
- Confusion about why auto-merge isn't working
- Version PRs that require manual merging

## Solution

1. **Add PAT validation step**: Check for AUTO_MERGE_PAT secret at the beginning of the workflow
2. **Fail fast**: Exit with error code 1 when PAT is missing, with clear instructions
3. **Remove fallback**: No longer fall back to GITHUB_TOKEN
4. **Clear error messages**: Provide setup instructions directly in the error output

## Benefits

- **Visibility**: Missing PAT configuration is immediately visible as a failed workflow
- **Clear requirements**: Makes it obvious that PAT is required for auto-merge
- **Better UX**: Provides actionable error messages with setup instructions
- **No silent failures**: Workflow fails properly instead of pretending to work

## Testing

After merging, the workflow will:
- ✅ Fail with clear error if AUTO_MERGE_PAT is not configured
- ✅ Show setup instructions in the workflow logs
- ✅ Only attempt auto-merge when properly configured