### PR TITLE
fix: add CHANGESETS_PAT as GITHUB_TOKEN for changeset version

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Apply changesets and version
         id: changesets
         if: steps.check-changesets.outputs.has_changesets == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}
         run: |
           # Get current version before changes
           CURRENT_VERSION=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

The CD workflow was failing because the @changesets/changelog-github package requires a GITHUB_TOKEN environment variable to fetch PR and user information from GitHub.

## Error
```
Error: Please create a GitHub personal access token at https://github.com/settings/tokens/new 
with `read:user` and `repo:status` permissions and add it as the GITHUB_TOKEN environment variable
```

## Fix
Added `GITHUB_TOKEN: ${{ secrets.CHANGESETS_PAT }}` to the environment variables for the 'Apply changesets and version' step.

This ensures the changeset version command has access to fetch GitHub information for generating proper changelog entries with PR links and author information.

## Test Plan
- [x] Workflow syntax is valid
- [ ] CD workflow will run successfully after merge
- [ ] Changesets will be applied and version will bump to 1.0.0