### PR TITLE
fix: use standalone pnpm to avoid npm registry rate limiting

### DIFF
--- a/.changeset/fix-ci-cd-improvements.md
+++ b/.changeset/fix-ci-cd-improvements.md
@@ -1,0 +1,24 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix: improve CI/CD reliability and performance
+
+**Fixes:**
+
+- Use standalone pnpm installation to avoid npm registry rate limiting (429 errors)
+- Add CHANGESETS_PAT as GITHUB_TOKEN for changeset version command
+- Make OSV Scanner depend on validate job for proper sequencing
+- Ensure build artifacts only created after security scans pass
+
+**Performance Improvements:**
+
+- Add explicit caching for pnpm binary to avoid re-downloads
+- Use environment variables for pnpm and node versions for maintainability
+
+**Security:**
+
+- Build artifacts now depend on security scans completing successfully
+- Ensures we don't build and attest to artifacts with known vulnerabilities
+
+These changes make the CI/CD pipeline more reliable, faster, and more secure.

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,6 +12,10 @@ concurrency:
   group: cd-${{ github.ref }}
   cancel-in-progress: false
 
+env:
+  PNPM_VERSION: 10.0.0
+  NODE_VERSION: 22
+
 permissions:
   contents: write
   packages: write
@@ -42,19 +46,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/setup-pnpm
-          key: pnpm-binary-10.0.0-${{ runner.os }}
+          key: pnpm-binary-${{ env.PNPM_VERSION }}-${{ runner.os }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.0.0
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
           standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies
@@ -213,19 +217,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/setup-pnpm
-          key: pnpm-binary-10.0.0-${{ runner.os }}
+          key: pnpm-binary-${{ env.PNPM_VERSION }}-${{ runner.os }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.0.0
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
           standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
           registry-url: 'https://registry.npmjs.org'
 
@@ -360,19 +364,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/setup-pnpm
-          key: pnpm-binary-10.0.0-${{ runner.os }}
+          key: pnpm-binary-${{ env.PNPM_VERSION }}-${{ runner.os }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.0.0
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
           standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           version: 10.0.0
           run_install: false
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -207,6 +208,7 @@ jobs:
         with:
           version: 10.0.0
           run_install: false
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -347,6 +349,7 @@ jobs:
         with:
           version: 10.0.0
           run_install: false
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,6 +38,12 @@ jobs:
           token: ${{ secrets.CHANGESETS_PAT || secrets.GITHUB_TOKEN }}
           fetch-depth: 0
 
+      - name: Cache pnpm binary
+        uses: actions/cache@v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-binary-10.0.0-${{ runner.os }}
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -203,6 +209,12 @@ jobs:
         with:
           ref: v${{ needs.release.outputs.version }}
 
+      - name: Cache pnpm binary
+        uses: actions/cache@v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-binary-10.0.0-${{ runner.os }}
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
@@ -343,6 +355,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: v${{ needs.release.outputs.version }}
+
+      - name: Cache pnpm binary
+        uses: actions/cache@v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-binary-10.0.0-${{ runner.os }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           version: 10.0.0
           run_install: false
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -81,6 +82,7 @@ jobs:
         with:
           version: 10.0.0
           run_install: false
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -125,6 +127,7 @@ jobs:
         with:
           version: 10.0.0
           run_install: false
+          standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
   build-artifacts:
     name: Build Artifacts
-    needs: [validate]
+    needs: [validate, security-scan-codeql, security-scan-osv]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
 
   security-scan-osv:
     name: OSV Scanner
-    if: github.event_name == 'pull_request'
+    needs: [validate]
     uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@v2.2.1
     permissions:
       actions: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+env:
+  PNPM_VERSION: 10.0.0
+  NODE_VERSION: 22
+
 permissions:
   contents: read
   id-token: write
@@ -126,19 +130,19 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/setup-pnpm
-          key: pnpm-binary-10.0.0-${{ runner.os }}
+          key: pnpm-binary-${{ env.PNPM_VERSION }}-${{ runner.os }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.0.0
+          version: ${{ env.PNPM_VERSION }}
           run_install: false
           standalone: true
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
 
       - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,7 @@ jobs:
 
   build-artifacts:
     name: Build Artifacts
-    needs: [validate, security-scan-codeql, security-scan-osv]
+    needs: [security-scan-codeql, security-scan-osv]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Cache pnpm binary
+        uses: actions/cache@v4
+        with:
+          path: ~/setup-pnpm
+          key: pnpm-binary-10.0.0-${{ runner.os }}
+
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary

The CI/CD workflows are failing with npm registry rate limiting (429 Too Many Requests) when installing pnpm.

## Error
```
WARN  GET https://registry.npmjs.org/pnpm error (429). Will retry in 10 seconds. 2 retries left.
ERR_PNPM_FETCH_429  GET https://registry.npmjs.org/pnpm: Too Many Requests - 429
```

## Fix

Added `standalone: true` to all pnpm/action-setup steps in both CI and CD workflows.

This makes pnpm download directly from GitHub releases instead of npm registry, avoiding rate limiting issues.

## Benefits

- No more 429 rate limit errors from npm registry
- Faster and more reliable pnpm installation
- Works better in high-traffic CI environments

## Test Plan

- [x] Workflow syntax is valid
- [ ] CI workflow runs successfully without rate limiting
- [ ] CD workflow runs successfully without rate limiting