### PR TITLE
fix: correct GITHUB_TOKEN secret reference in release creation

### DIFF
--- a/.changeset/fix-github-token-release.md
+++ b/.changeset/fix-github-token-release.md
@@ -1,0 +1,8 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+Fix GITHUB_TOKEN secret reference in release creation
+
+- Changed `secrets.github-token` to `secrets.GITHUB_TOKEN` in the Create GitHub Release step
+- This ensures the release is created with proper permissions to trigger subsequent workflows

--- a/.changeset/fix-github-token-release.md
+++ b/.changeset/fix-github-token-release.md
@@ -2,7 +2,8 @@
 'agentic-node-ts-starter': patch
 ---
 
-Fix GITHUB_TOKEN secret reference in release creation
+Fix GITHUB_TOKEN secret reference in release creation workflow
 
 - Changed `secrets.github-token` to `secrets.GITHUB_TOKEN` in the Create GitHub Release step
 - This ensures the release is created with proper permissions to trigger subsequent workflows
+- Also reorganized YAML properties for better readability (moved release flags before files list)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -302,15 +302,15 @@ jobs:
           tag_name: v${{ steps.version.outputs.version }}
           name: v${{ steps.version.outputs.version }}
           body_path: release-notes.md
+          draft: false
+          prerelease: false
+          make_latest: true
           files: |
             sbom.cdx.json
             dist-${{ steps.version.outputs.version }}.tar.gz
             dist-${{ steps.version.outputs.version }}.zip
-          draft: false
-          prerelease: false
-          make_latest: true
         env:
-          GITHUB_TOKEN: ${{ secrets.github-token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Generate attestations
         if: steps.version.outputs.changed == 'true'


### PR DESCRIPTION
## Summary
- Fixed incorrect secret reference in the Create GitHub Release step
- Changed `secrets.github-token` to `secrets.GITHUB_TOKEN` to ensure proper permissions

## Problem
The publish workflow was not being triggered after releases were created by the main workflow. This was due to using an incorrect secret reference (`github-token` instead of `GITHUB_TOKEN`), which likely resulted in the release being created without proper permissions to trigger subsequent workflows.

## Solution
Updated the GITHUB_TOKEN environment variable in the Create GitHub Release step to use the correct secret reference.

## Test plan
- [x] Verify the workflow file is valid YAML
- [x] Confirm all checks pass
- [ ] After merge, the next release should properly trigger the publish workflow

🤖 Generated with [Claude Code](https://claude.ai/code)