### PR TITLE
fix: remove secrets from if conditions in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,8 +59,19 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Check NPM token
+        id: check-npm
+        run: |
+          if [ -n "${{ secrets.NPM_TOKEN }}" ]; then
+            echo "has_token=true" >> $GITHUB_OUTPUT
+            echo "✅ NPM_TOKEN is configured"
+          else
+            echo "has_token=false" >> $GITHUB_OUTPUT
+            echo "⚠️ NPM_TOKEN is not configured, skipping publish"
+          fi
+
       - name: Publish to NPM
-        if: ${{ secrets.NPM_TOKEN != '' }}
+        if: steps.check-npm.outputs.has_token == 'true'
         run: |
           # Remove private flag if present
           jq 'del(.private)' package.json > tmp.json && mv tmp.json package.json
@@ -118,7 +129,7 @@ jobs:
   docker:
     name: Publish to Docker Hub
     runs-on: ubuntu-latest
-    if: vars.ENABLE_DOCKER_RELEASE == 'true' && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''
+    if: vars.ENABLE_DOCKER_RELEASE == 'true'
     steps:
       - name: Determine version
         id: version
@@ -133,13 +144,28 @@ jobs:
         with:
           ref: v${{ steps.version.outputs.version }}
 
+      - name: Check Docker credentials
+        id: check-docker
+        run: |
+          if [ -n "${{ secrets.DOCKERHUB_USERNAME }}" ] && [ -n "${{ secrets.DOCKERHUB_TOKEN }}" ]; then
+            echo "has_credentials=true" >> $GITHUB_OUTPUT
+            echo "✅ Docker Hub credentials are configured"
+          else
+            echo "has_credentials=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Docker Hub credentials are not configured, skipping publish"
+            exit 0
+          fi
+
       - name: Set up QEMU
+        if: steps.check-docker.outputs.has_credentials == 'true'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
+        if: steps.check-docker.outputs.has_credentials == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
+        if: steps.check-docker.outputs.has_credentials == 'true'
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -147,6 +173,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
+        if: steps.check-docker.outputs.has_credentials == 'true'
         uses: docker/metadata-action@v5
         with:
           images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ github.event.repository.name }}
@@ -157,6 +184,7 @@ jobs:
             type=raw,value=latest
 
       - name: Build and push
+        if: steps.check-docker.outputs.has_credentials == 'true'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -170,11 +198,21 @@ jobs:
 
   notify:
     name: Notify
-    if: always() && secrets.SLACK_WEBHOOK != ''
+    if: always()
     needs: [npm, docker, github-packages]
     runs-on: ubuntu-latest
     steps:
+      - name: Check Slack webhook
+        id: check-slack
+        run: |
+          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
+            echo "has_webhook=true" >> $GITHUB_OUTPUT
+          else
+            echo "has_webhook=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Send Slack notification
+        if: steps.check-slack.outputs.has_webhook == 'true'
         uses: slackapi/slack-github-action@v2
         with:
           payload: |


### PR DESCRIPTION
## Summary
Fixes a critical issue where secrets were used in job-level `if` conditions, which is not allowed by GitHub Actions.

## Problem
GitHub Actions does not allow secrets to be referenced in job-level `if` conditions. This was causing:
- Line 63: `if: ${{ secrets.NPM_TOKEN != '' }}` (step level)
- Line 121: `if: vars.ENABLE_DOCKER_RELEASE == 'true' && secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != ''` (job level)
- Line 173: `if: always() && secrets.SLACK_WEBHOOK != ''` (job level)

## Solution
Move all secret checks to runtime steps:
- Add explicit credential checking steps that set outputs
- Use step outputs in subsequent step conditions
- This ensures the workflow is syntactically valid

## Changes
- ✅ Add `Check NPM token` step before publishing to NPM
- ✅ Add `Check Docker credentials` step before Docker operations  
- ✅ Add `Check Slack webhook` step before sending notifications
- ✅ Use step outputs for conditional execution

## Test Plan
- [ ] Workflow passes YAML validation
- [ ] Jobs run when credentials are configured
- [ ] Jobs skip gracefully when credentials are missing
- [ ] No syntax errors in GitHub Actions

🤖 Generated with [Claude Code](https://claude.ai/code)