### PR TITLE
docs: fix release documentation to reflect automated Changesets workflow

### DIFF
--- a/.changeset/fix-release-documentation.md
+++ b/.changeset/fix-release-documentation.md
@@ -1,0 +1,11 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+Fix release documentation to reflect automated Changesets workflow
+
+- Updated `.claude/commands/release.md` to accurately describe the automated release process
+- Removed outdated manual version bumping and changelog editing instructions
+- Emphasized PR-only workflow (no direct pushes to main)
+- Added proper troubleshooting steps for the automated workflow
+- Clarified that releases are fully automated via GitHub Actions when changesets are merged

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,26 +1,132 @@
 # Release a new version
 
-You are about to make a release of the project. Please follow these steps:
+This project uses an **automated release process** powered by Changesets. Releases happen automatically when changes with changesets are merged to the main branch.
 
-1. **Create a new branch** for the release, e.g., `release/v1.0.0`.
-2. **Update the version number** in `package.json` according to [Semantic Versioning](https://semver.org/) and based on the changes made since the last release.
-3. **Update the changelog** in `CHANGELOG.md` to reflect the changes made in this release. Use the `date` command to get the current date in the format `YYYY-MM-DD`.
-   Use the following format for the changelog entry:
+## How Releases Work
 
+### Automatic Release Process
+
+1. **During Development**: When you make changes, add a changeset:
+
+   ```bash
+   pnpm changeset
    ```
-   ## [v1.0.0] - YYYY-MM-DD
-   - Description of changes
-   - Another change
-   ```
 
-4. Update the README.md file if necessary, ensuring it reflects the latest changes and version number.
-5. **Commit the changes** making sure that the pre-commit hook passes without warnings or errors. ^:wq
-6. **Push the branch** to the remote repository.
-7. **Create a pull request** to trigger the CI/CD pipeline.
-8. **Wait for the CI/CD pipeline to complete** successfully. Ensure that all tests pass and the build is successful.
-9. **Merge the pull request** into the main branch once the CI/CD pipeline has passed. The merge should be done using the "Squash and merge" option to keep the commit history clean and the branch should be deleted after merging.
-10. **Make the release** by using the `gh` CLI tool:
+   - Select the type of change (patch/minor/major)
+   - Provide a description for the changelog
+
+2. **On PR Merge**: When your PR with a changeset is merged to main:
+   - GitHub Actions automatically runs the release workflow
+   - The workflow checks for pending changesets
+   - If changesets exist, it automatically:
+     - Updates version in `package.json`
+     - Generates/updates `CHANGELOG.md`
+     - Creates a git tag
+     - Commits changes with `[skip actions]` to prevent loops
+     - Creates a GitHub Release with artifacts
+     - Publishes to npm (if configured)
+
+3. **No Manual Steps Required**: The entire process is automated!
+
+## Creating a Release
+
+### Standard Release (Recommended)
+
+All releases happen through pull requests:
 
 ```bash
-gh release create v1.0.0 --title "Release v1.0.0" --notes "Release notes for v1.0.0"
+# On your feature branch
+pnpm changeset  # Add changeset for your changes
+git add .
+git commit -m "feat: your feature"
+git push origin your-branch
+
+# Create PR via GitHub CLI or web interface
+gh pr create --title "feat: your feature" --body "Description"
+
+# After PR review and approval, merge it
+# Release happens automatically after merge!
 ```
+
+### Hotfix Release
+
+For urgent fixes, still use the PR process:
+
+1. Create a hotfix branch from main
+2. Make your fix and add a changeset
+3. Create and merge PR with expedited review
+4. The release workflow will automatically trigger after merge
+
+### Monitoring Releases
+
+Watch the release process:
+
+```bash
+# View recent workflow runs
+gh run list --workflow=main.yml
+
+# Watch a specific run
+gh run watch <run-id>
+
+# View releases
+gh release list
+```
+
+## What Happens Automatically
+
+When changesets are detected on main branch:
+
+1. **Version Bump**: Based on changeset types (patch/minor/major)
+2. **CHANGELOG Update**: Generated from changeset descriptions
+3. **Git Tag**: Created as `v{version}`
+4. **GitHub Release**: Created with:
+   - Release notes from CHANGELOG
+   - Build artifacts (dist files)
+   - SBOM (Software Bill of Materials)
+5. **NPM Publish**: If `NPM_TOKEN` secret is configured
+6. **Attestations**: Build provenance for security
+
+## Release Types
+
+- **patch** (0.0.X): Bug fixes, documentation updates
+- **minor** (0.X.0): New features, non-breaking changes
+- **major** (X.0.0): Breaking changes
+
+## Troubleshooting
+
+### No Release Triggered
+
+- Check if changesets exist: `ls .changeset/*.md`
+- Verify changesets are not empty
+- Check workflow runs: `gh run list --workflow=main.yml`
+
+### Release Failed
+
+- Check GitHub Actions logs
+- Verify all tests pass: `pnpm verify`
+- Ensure build succeeds: `pnpm build`
+
+### Manual Version Bump (Not Recommended)
+
+If absolutely necessary:
+
+```bash
+# This is handled automatically - avoid manual changes!
+pnpm changeset version  # Updates version and CHANGELOG
+```
+
+## Important Notes
+
+- **Always** use pull requests - never push directly to main
+- **Never** manually edit version in `package.json`
+- **Never** manually create release tags
+- **Never** manually edit CHANGELOG.md (except for corrections)
+- Always use changesets for version management
+- The `[skip actions]` tag prevents release commit loops
+- All releases must go through the PR review process
+
+## Related Documentation
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) - Changeset guidelines
+- [.github/workflows/main.yml](../../.github/workflows/main.yml) - Release workflow
+- [Changesets Documentation](https://github.com/changesets/changesets) - Official docs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -84,14 +84,14 @@ specs/            # Feature specifications in Gherkin format
 - **Single-user workflow**: Simplified for individual developers without branch protection
 - **Release automation**: Automatically creates version PRs and manages releases
 
-### Development Process (Simplified)
+### Development Process
 
 1. Write/update specifications in `specs/SPEC.md`
 2. Implement with tests (property-based for core logic)
 3. Run `pnpm verify` before committing
 4. Use Conventional Commits format (`feat:`, `fix:`, etc.)
-5. **Optional**: Create changeset for detailed release notes
-6. Push directly to main or create PR for review
+5. Add a changeset for your changes: `pnpm changeset`
+6. Create a pull request for review - **never push directly to main**
 
 ## GitHub CLI Commands
 
@@ -108,12 +108,12 @@ Common gh commands for this repository:
 Available slash commands in `.claude/commands/`:
 
 - `/analyze-and-fix-github-issue` - Analyze and fix a GitHub issue with full workflow
-- `/release` - Create a new version release following semantic versioning
+- `/release` - Guide for the automated Changesets release process
 - `/update-dependencies` - Update all dependencies to latest versions with PR workflow
 
 ## Configuration
 
-- **Package Manager**: pnpm 10.0.0 (specified in package.json)
+- **Package Manager**: pnpm 10.15.0 (specified in package.json)
 - **Node Version**: >=22.0.0 (engines requirement)
 - **TypeScript**: Strict mode with NodeNext module resolution
 - **Testing**: Vitest with V8 coverage provider
@@ -169,26 +169,27 @@ The CI will validate that a changeset is present, and the release workflow will 
 
 1. **Always run `pnpm verify`** - Ensures all checks pass (typecheck, lint, format, tests)
 2. **Use conventional commits** - Format: `type(scope): description` (e.g., `feat: add dark mode`)
-3. **Changesets are optional** - Create one for detailed release notes, or let CI auto-generate from commits
+3. **Add changesets** - Run `pnpm changeset` to document your changes for the release notes
 4. **Use the correct import syntax** - Always use `.js` extension for local ES module imports
 
-### CI/CD Workflow (Simplified)
+### CI/CD Workflow
 
-- **Ultra-simple workflow**: `.github/workflows/ci-cd.yml` - Streamlined single-user workflow (~260 lines, 70% reduction)
-- **Three jobs only**: `validate` (all checks), `release` (auto-changelog), `publish-npm` (optional)
-- **Direct commits to main**: No PR creation for releases, immediate push
-- **Hybrid changelog**: Uses changesets if present, auto-generates from conventional commits if not
+- **PR validation**: `.github/workflows/pr.yml` - Runs all checks on pull requests
+- **Release automation**: `.github/workflows/main.yml` - Handles releases when PRs are merged
 - **Parallel validation**: All checks run simultaneously for faster CI
+- **Changeset-driven releases**: Uses changesets for version management and changelog generation
+- **Security scanning**: CodeQL and OSV vulnerability scanning on all PRs
 
 ### Automatic Release Process
 
-The simplified workflow automatically handles releases on every push to main:
+The workflow automatically handles releases when PRs with changesets are merged to main:
 
-1. **Checks for changesets** or conventional commits (`feat:`, `fix:`, etc.)
-2. **Auto-generates changelog** from commits if no changeset exists
-3. **Versions and tags** directly on main (no PR needed)
-4. **Creates GitHub release** with changelog and SBOM
-5. **Publishes to npm** if NPM_TOKEN is configured
+1. **PR merge triggers workflow** - Main workflow runs after PR is merged
+2. **Checks for changesets** - Determines if a release is needed
+3. **Versions and tags automatically** - Updates version, generates CHANGELOG.md
+4. **Creates GitHub release** - With changelog, build artifacts, and SBOM
+5. **Publishes to npm** - If NPM_TOKEN is configured
+6. **Uses [skip actions]** - Prevents release commits from triggering duplicate workflows
 
 Key principle: **No duplicate builds** - The workflow checks out code at the release tag and builds only what's needed for each distribution channel.
 


### PR DESCRIPTION
## Summary

Fixes inconsistency between the release documentation and the actual automated workflow. The `/release` command guide was describing a manual release process that conflicted with our automated Changesets pipeline.

## Problem
- The `.claude/commands/release.md` file instructed manual version bumping and changelog editing
- Documentation suggested pushing directly to main, which violates our PR-only workflow  
- Instructions didn't reflect the actual automated release process triggered by merging PRs with changesets

## Changes
- ✅ Updated `.claude/commands/release.md` to accurately describe the automated release process
- ✅ Removed all manual version/changelog editing instructions
- ✅ Emphasized PR-only workflow throughout documentation
- ✅ Updated `CLAUDE.md` to reinforce PR-based development
- ✅ Added proper troubleshooting guidance for the automated workflow
- ✅ Fixed pnpm version reference to match current 10.15.0

## Testing
- Documentation reviewed for accuracy against actual workflow
- All pre-commit checks pass
- Changeset included for this update

Closes the issue raised about release documentation inconsistency.

🤖 Generated with [Claude Code](https://claude.ai/code)