### PR TITLE
docs: fix version inconsistencies across documentation and config files

### DIFF
--- a/.changeset/fix-version-consistency.md
+++ b/.changeset/fix-version-consistency.md
@@ -1,0 +1,10 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+Fix version inconsistencies in documentation
+
+- Updated README.md to show pnpm 10.15.0 instead of 10.0.0
+- Updated Dockerfile to use pnpm 10.15.0 for consistency
+- Updated mise.toml to specify exact pnpm version 10.15.0
+- Ensures all configuration files and documentation reference the same tool versions

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM node:22-alpine AS builder
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
 # Set working directory
 WORKDIR /app
@@ -23,7 +23,7 @@ RUN pnpm build
 FROM node:22-alpine
 
 # Install pnpm
-RUN corepack enable && corepack prepare pnpm@10.0.0 --activate
+RUN corepack enable && corepack prepare pnpm@10.15.0 --activate
 
 # Install dumb-init for proper signal handling
 RUN apk add --no-cache dumb-init

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A **batteries-included** starting point for building software with an **agentic 
 ### Core Technologies
 
 - **Runtime:** Node.js 22+ via **mise** (`mise.toml`)
-- **Package Manager:** **pnpm 10.0.0** (pinned in package.json)
+- **Package Manager:** **pnpm 10.15.0** (pinned in package.json)
 - **Language:** TypeScript 5.9+ with strict mode
 - **Testing:** Vitest 3.2+ with V8 coverage
 - **Property Testing:** fast-check 4.2+
@@ -39,7 +39,7 @@ A **batteries-included** starting point for building software with an **agentic 
 ### Setup
 
 ```bash
-# Install Node 22 + pnpm 10 via mise
+# Install Node 22 + pnpm 10.15.0 via mise
 mise install
 
 # Install dependencies

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,3 @@
 [tools]
 node = "22"
-pnpm = "10"
+pnpm = "10.15.0"


### PR DESCRIPTION
## Summary

Fixes version inconsistencies where documentation claimed different tool versions than what's actually configured. This ensures users have accurate information about the exact versions being used.

## Issue
- README stated "pnpm 10.0.0" but package.json specifies "pnpm@10.15.0"
- Dockerfile used outdated pnpm 10.0.0 version
- mise.toml didn't specify exact pnpm version

## Changes
- ✅ Updated README.md to show correct pnpm version (10.15.0)
- ✅ Updated Dockerfile to use pnpm 10.15.0 for consistency
- ✅ Updated mise.toml to specify exact pnpm version 10.15.0
- ✅ Verified Node.js 22 references are consistent throughout

## Testing
- All pre-commit checks pass
- Documentation reviewed for accuracy
- Configuration files tested for consistency

This ensures all configuration files and documentation reference the same tool versions, preventing confusion about which exact versions are required.

🤖 Generated with [Claude Code](https://claude.ai/code)