### PR TITLE
fix: fix Husky pre-commit hook configuration and clarify script purposes

### DIFF
--- a/.changeset/fix-husky-precommit.md
+++ b/.changeset/fix-husky-precommit.md
@@ -1,0 +1,12 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+Fix Husky pre-commit hook configuration and rename scripts for clarity
+
+- Fixed missing shebang line in `.husky/pre-commit` hook
+- Renamed `verify` script to `precommit` to better indicate its purpose
+- Created `verify` as an alias to `precommit` for backwards compatibility
+- Renamed old `precommit` script to `lint-staged` for clarity
+- Updated documentation to reflect that pre-commit runs ALL checks
+- Pre-commit hook now correctly runs comprehensive checks on every commit

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,3 @@
-pnpm verify
+#!/usr/bin/env sh
+
+pnpm precommit

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm lint:fix` - Auto-fix linting issues
 - `pnpm format` - Check Prettier formatting
 - `pnpm format:fix` - Apply Prettier formatting
-- `pnpm verify` - Run all checks (audit, typecheck, lint, format, test)
+- `pnpm precommit` - Run all checks (audit, typecheck, lint, format, test)
+- `pnpm verify` - Alias for pnpm precommit (for backwards compatibility)
 
 ### Testing
 
@@ -36,7 +37,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm release` - Version packages with Changesets and build
 - `pnpm release:publish` - Build and publish packages
 - `pnpm release:tag` - Commit changes and create git tag for release
-- `pnpm precommit` - Run lint-staged (automatically triggered by Husky)
+- `pnpm lint-staged` - Run lint-staged (formats and lints staged files only)
 
 ## Architecture & Patterns
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,11 +52,13 @@ git checkout -b fix/your-fix-name
 
 ### 3. Run Quality Checks
 
-Before committing, ensure all checks pass:
+Before committing, you can manually run all checks:
 
 ```bash
 pnpm verify  # Runs all checks: audit, typecheck, lint, format, test
 ```
+
+Note: The pre-commit hook will automatically run all these checks when you commit.
 
 Individual checks:
 
@@ -120,9 +122,14 @@ git commit -m "feat: add new validation for user input"
 
 Pre-commit hooks will automatically:
 
-- Format your code with Prettier
-- Lint with ESLint
-- Validate commit message format
+- Run security audit
+- Type check your code
+- Run ESLint checks
+- Run Prettier format checks
+- Run all tests
+- Validate commit message format (via commit-msg hook)
+
+Note: The pre-commit hook runs `pnpm precommit` which executes ALL quality checks. This ensures code quality but may take longer than typical pre-commit hooks.
 
 ### 6. Push and Create a Pull Request
 

--- a/package.json
+++ b/package.json
@@ -18,15 +18,16 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --reporter=verbose --coverage",
     "coverage:report": "vitest run --coverage --reporter=verbose",
-    "verify": "pnpm audit --audit-level critical && pnpm typecheck && pnpm lint && pnpm format && pnpm test",
+    "precommit": "pnpm audit --audit-level critical && pnpm typecheck && pnpm lint && pnpm format && pnpm test",
+    "verify": "pnpm precommit",
+    "lint-staged": "lint-staged",
     "sbom": "pnpm dlx @cyclonedx/cdxgen -o sbom.cdx.json",
     "prepare": "husky",
     "release": "changeset version && pnpm build",
     "release:publish": "pnpm build && changeset publish",
     "release:tag": "git add -A && git commit -m \"chore(release): version packages\" && git tag -a v$(node -p \"require('./package.json').version\") -m \"Release\"",
     "changeset": "changeset",
-    "changeset:status": "changeset status --since=main",
-    "precommit": "lint-staged"
+    "changeset:status": "changeset status --since=main"
   },
   "lint-staged": {
     "*.{ts,tsx,js,json,md,yml,yaml}": [


### PR DESCRIPTION
## Summary

Fixes the broken Husky pre-commit hook and clarifies script naming for better understanding of their purposes.

## Issues Fixed

1. **Broken pre-commit hook**: The `.husky/pre-commit` file was missing the required shebang line
2. **Confusing script names**: The `verify` script name didn't clearly indicate it runs on pre-commit

## Changes

- ✅ Fixed missing shebang line (`#!/usr/bin/env sh`) in `.husky/pre-commit` 
- ✅ Renamed `verify` script to `precommit` to better indicate its purpose
- ✅ Created `verify` as an alias to `precommit` for backwards compatibility
- ✅ Renamed old `precommit` script to `lint-staged` for clarity
- ✅ Updated CONTRIBUTING.md to clarify that pre-commit runs ALL checks
- ✅ Updated CLAUDE.md to reflect the script changes

## Behavior

The pre-commit hook continues to run **all quality checks** on every commit:
- Security audit
- Type checking
- ESLint
- Prettier formatting check
- All tests

This ensures comprehensive quality control but may take longer than typical pre-commit hooks. This is intentional to maintain high code quality standards.

## Testing

- Pre-commit hook tested and working correctly
- All checks pass successfully
- Documentation reviewed for accuracy

🤖 Generated with [Claude Code](https://claude.ai/code)