### PR TITLE
fix: remove implementation checklist from spec-feature command

### DIFF
--- a/.claude/commands/spec-feature.md
+++ b/.claude/commands/spec-feature.md
@@ -26,7 +26,6 @@ You are about to create a feature specification in Gherkin format and turn it in
    - Labels: `enhancement`, `needs-implementation`
    - Milestone (if applicable)
    - Complete Gherkin specification in the body
-   - Implementation checklist
    - Testing requirements
 
 4. **Create the Issue**
@@ -108,16 +107,6 @@ Feature: [Feature Name]
 - Security considerations: [if any]
 - Dependencies: [external dependencies or prerequisites]
 
-### Implementation Checklist
-
-- [ ] Implement core functionality
-- [ ] Add comprehensive unit tests
-- [ ] Add property-based tests for invariants
-- [ ] Add integration tests if needed
-- [ ] Update documentation
-- [ ] Add changeset for release notes
-- [ ] Ensure all quality checks pass (`pnpm verify`)
-
 ### Testing Requirements
 
 - Unit test coverage for all new functions
@@ -162,10 +151,7 @@ I want to securely log in to the application
 So that I can access my personal data and features
 
 ### Gherkin Specification
-[... full specification ...]
-
-### Implementation Checklist
-[... checklist items ...]" \
+[... full specification ...]" \
   --label enhancement \
   --label needs-implementation
 ````


### PR DESCRIPTION
## Summary

Removes the redundant Implementation Checklist section from the spec-feature command template.

## Changes

- Removed Implementation Checklist section from the issue template
- Removed references to Implementation Checklist in the process description
- Cleaned up the example output to match the updated template

## Rationale

The Implementation Checklist was redundant with:
- **Acceptance Criteria**: Already defines what needs to be done
- **Definition of Done**: Already covers quality and completion requirements
- **Testing Requirements**: Already specifies testing needs

Having both creates unnecessary duplication and potential confusion about which checklist to follow.

## Impact

- Simplifies the spec-feature command output
- Reduces redundancy in generated GitHub issues
- Makes specs more focused on requirements rather than implementation details