### PR TITLE
docs: fix incorrect PAT environment variable name in README

### DIFF
--- a/.changeset/fix-pat-documentation.md
+++ b/.changeset/fix-pat-documentation.md
@@ -1,0 +1,8 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+docs: fix incorrect PAT environment variable name in README
+
+- Changed GH_RELEASE_TOKEN to RELEASE_TOKEN to match actual workflow usage
+- This corrects the documentation to reflect the actual secret name used in GitHub Actions

--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ See [CLAUDE.md](./CLAUDE.md) for detailed Claude Code guidance.
 
 **For automated releases**, add secrets:
 
-- `GH_RELEASE_TOKEN` - PAT with repo/workflow scopes
+- `RELEASE_TOKEN` - GitHub PAT with repo/workflow scopes (triggers publish workflow)
 - `NPM_TOKEN` - For npm publishing (optional)
 
 ## 📦 Release Distribution Setup


### PR DESCRIPTION
## Summary

This PR corrects the documentation to use the actual PAT environment variable name used in the GitHub Actions workflows.

## Changes

- Changed  to  in README.md
- This matches the actual secret name used in 

## Why?

The README incorrectly referenced  but the workflows actually use . This was causing confusion for users trying to set up automated releases.

## Impact

- ✅ Documentation now accurately reflects the required secret name
- ✅ Users will configure the correct secret for automatic publishing

🤖 Generated with [Claude Code](https://claude.ai/code)