### PR TITLE
fix(docs): correct logger function references in documentation

### DIFF
--- a/.changeset/fix-logger-documentation.md
+++ b/.changeset/fix-logger-documentation.md
@@ -1,0 +1,11 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+docs: fix incorrect logger function references in documentation
+
+- Fixed docs/OBSERVABILITY.md to use correct logger imports (logger instead of createLogger)
+- Fixed docs/PATTERNS.md to use correct logger imports (logger instead of createLogger)
+- Documentation now accurately reflects the actual exports from src/logger.ts
+
+Closes #95

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -14,14 +14,16 @@ This template includes **Pino** for structured logging, with patterns ready for 
 ### Using the Logger
 
 ```typescript
-import { createLogger, createChildLogger } from './logger.js';
+import { logger, createChildLogger } from './logger.js';
 
-// Basic logging
-const logger = createLogger('my-module');
+// Basic logging with the default logger
 logger.info('Application started');
 logger.error({ err: error }, 'Operation failed');
 
-// Child loggers for context
+// Child loggers for module-specific context
+const myModuleLogger = createChildLogger('my-module');
+myModuleLogger.info('Module initialized');
+
 const dbLogger = createChildLogger('database');
 dbLogger.debug({ query: 'SELECT *', duration: 45 }, 'Query executed');
 ```

--- a/docs/PATTERNS.md
+++ b/docs/PATTERNS.md
@@ -137,16 +137,16 @@ describe('calculateDiscount', () => {
 ### Basic Logging Setup
 
 ```typescript
-import { createLogger, createChildLogger } from './logger.js';
+import { logger, createChildLogger } from './logger.js';
 
-// Create a root logger
-const logger = createLogger('app');
-
-// Log with structured data
+// Use the default logger for general application logging
 logger.info({ userId: '123', action: 'login' }, 'User logged in');
 logger.error({ err: new Error('Connection failed'), retries: 3 }, 'Database error');
 
-// Create child loggers for modules
+// Create child loggers for module-specific logging
+const appLogger = createChildLogger('app');
+appLogger.info('Application initialized');
+
 const dbLogger = createChildLogger('database');
 dbLogger.debug({ query: 'SELECT * FROM users', duration: 45 }, 'Query executed');
 ```


### PR DESCRIPTION
## Summary

Fixes documentation to use the correct logger API exports from `src/logger.ts`.

## Changes

- Updated `docs/OBSERVABILITY.md` to use `logger` singleton instead of non-existent `createLogger` function
- Updated `docs/PATTERNS.md` to use `logger` singleton instead of non-existent `createLogger` function  
- All examples now correctly demonstrate using either the `logger` singleton or `createChildLogger` for module-specific loggers

## Test Plan

- [x] Verified all documentation examples align with actual exports from `src/logger.ts`
- [x] Ran `pnpm verify` - all checks pass
- [x] Documentation tests pass

Closes #95

🤖 Generated with [Claude Code](https://claude.ai/code)