### PR TITLE
fix: resolve race condition in logger-output tests

### DIFF
--- a/tests/logger-output.spec.ts
+++ b/tests/logger-output.spec.ts
@@ -37,8 +37,9 @@ describe('Logger Output Configuration', () => {
     process.env = originalEnv;
     vi.clearAllMocks();
 
-    // Add a small delay to let any async file operations complete
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    // Add a delay to let any async file operations complete
+    // Increase delay for file-based tests to ensure pino-roll finishes
+    await new Promise((resolve) => setTimeout(resolve, 50));
 
     // Clean up test log directory with error handling
     if (existsSync(testLogDir)) {
@@ -338,6 +339,7 @@ describe('Logger Output Configuration', () => {
 
     it('should preserve child logger functionality with file output', async () => {
       process.env.LOG_OUTPUT = 'file';
+      process.env.LOG_FILE_PATH = testLogFile;
       process.env.NODE_ENV = 'development';
 
       const loggerModule = await import('../src/logger.js');
@@ -374,7 +376,13 @@ describe('Logger Output Configuration', () => {
     });
 
     it('should maintain correlation ID support with different outputs', async () => {
+      // Ensure directory exists for this test
+      if (!existsSync(testLogDir)) {
+        mkdirSync(testLogDir, { recursive: true });
+      }
+
       process.env.LOG_OUTPUT = 'file';
+      process.env.LOG_FILE_PATH = testLogFile;
       process.env.NODE_ENV = 'production';
       process.env.CORRELATION_ID = 'test-correlation-123';
 
@@ -493,6 +501,7 @@ describe('Logger Output Configuration', () => {
     it('should work correctly in development with file output', async () => {
       process.env.NODE_ENV = 'development';
       process.env.LOG_OUTPUT = 'file';
+      process.env.LOG_FILE_PATH = testLogFile;
 
       const loggerModule = await import('../src/logger.js');
       logger = loggerModule.logger;


### PR DESCRIPTION
## Summary
- Fixed intermittent test failures in logger-output.spec.ts that were causing CI/CD pipeline failures
- Added explicit LOG_FILE_PATH to tests that use file output to prevent conflicts
- Increased cleanup delay from 10ms to 50ms to allow async file operations to complete
- Ensured test directory exists before production tests with file output

## Problem
The tests were experiencing race conditions when:
1. Multiple tests used file output without specifying unique paths
2. The logger in production mode immediately writes initialization logs
3. Async file operations from pino-roll were still in progress during cleanup

## Solution
- Each test that uses file output now explicitly sets LOG_FILE_PATH to testLogFile
- Increased afterEach cleanup delay to give pino-roll time to finish
- Added directory existence check for production file output test

## Test Results
✅ All tests pass consistently (verified with multiple runs)
✅ No more ENOENT errors
✅ CI/CD pipeline should now be stable

Fixes the intermittent test failures seen in PR #108 and other recent builds.