### PR TITLE
fix: correct changeset config path to compiled JS location

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.1/schema.json",
   "changelog": [
-    "./dev/changelog-custom.js",
+    "./dist/src/dev/changelog-custom.js",
     {
       "repo": "sapientpants/agentic-node-ts-starter"
     }


### PR DESCRIPTION
## Summary
- Fixed CI/CD pipeline failure caused by incorrect changeset config path
- Updated path from `./dev/changelog-custom.js` to `./dist/src/dev/changelog-custom.js`
- The custom changelog module is a TypeScript file that gets compiled to the dist directory

## Context
The CI/CD pipeline was failing with `MODULE_NOT_FOUND` error because the changeset config was pointing to a non-existent file. The actual TypeScript file at `src/dev/changelog-custom.ts` is compiled to `dist/src/dev/changelog-custom.js` during the build process.

## Test plan
- [x] Verified `pnpm changeset status` works locally after building
- [x] Confirmed the compiled JS file exists at the correct path
- [ ] CI/CD pipeline should pass with this fix

🤖 Generated with [Claude Code](https://claude.ai/code)