### PR TITLE
fix: add build step before changeset version in CI/CD

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -117,6 +117,16 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       # =============================================================================
+      # BUILD FOR CHANGESET
+      # Build TypeScript to ensure custom changelog generator is available
+      # =============================================================================
+
+      - name: Build for changeset
+        # Must build before versioning since custom changelog is TypeScript
+        # The compiled JS file is needed at: ./dist/src/dev/changelog-custom.js
+        run: pnpm build
+
+      # =============================================================================
       # VERSION MANAGEMENT
       # Determines if release needed based on changesets
       # =============================================================================
@@ -139,8 +149,11 @@ jobs:
 
       - name: Build
         # Skip build if no version change (e.g., docs-only commits)
+        # Clean and rebuild to ensure SBOM reflects exact build artifacts
         if: steps.version.outputs.changed == 'true'
-        run: pnpm build
+        run: |
+          pnpm clean  # Remove any previous build artifacts
+          pnpm build  # Fresh build for release
 
       - name: Generate SBOM
         # Software Bill of Materials for supply chain security


### PR DESCRIPTION
## Summary
- Added initial build step before running changeset version command
- Added clean step before release build to ensure accurate SBOM generation
- Fixes MODULE_NOT_FOUND error for custom changelog generator in CI/CD

## Problem
The CI/CD pipeline was failing because:
1. The custom changelog generator is written in TypeScript (`src/dev/changelog-custom.ts`)
2. Changeset config references the compiled JS file (`./dist/src/dev/changelog-custom.js`)
3. The build step was only running AFTER the version step, causing a MODULE_NOT_FOUND error

## Solution
1. Added a "Build for changeset" step immediately after installing dependencies
2. This ensures the TypeScript files are compiled before changeset tries to use them
3. Also added `pnpm clean` before the release build to ensure SBOM reflects exact release artifacts

## Test plan
- [ ] CI/CD pipeline should pass the version step
- [ ] Custom changelog should generate correctly
- [ ] SBOM should reflect clean build artifacts

🤖 Generated with [Claude Code](https://claude.ai/code)