### PR TITLE
fix(ci): decouple checkout from RELEASE_TOKEN

### DIFF
--- a/.changeset/fix-release-token-checkout.md
+++ b/.changeset/fix-release-token-checkout.md
@@ -1,0 +1,5 @@
+---
+'agentic-node-ts-starter': patch
+---
+
+fix(ci): decouple checkout from RELEASE_TOKEN to prevent authentication failures

--- a/.changeset/fix-release-token-fallback.md
+++ b/.changeset/fix-release-token-fallback.md
@@ -1,5 +1,0 @@
----
-'agentic-node-ts-starter': patch
----
-
-fix(ci): add GITHUB_TOKEN fallback when RELEASE_TOKEN secret is missing or expired

--- a/.changeset/fix-release-token-validation.md
+++ b/.changeset/fix-release-token-validation.md
@@ -1,5 +1,0 @@
----
-'agentic-node-ts-starter': patch
----
-
-fix(ci): validate RELEASE_TOKEN works before using it in downstream jobs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -125,13 +124,16 @@ jobs:
 
       - name: Commit quality metrics
         if: steps.check_changes.outputs.changed == 'true'
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
           git config --local user.name "${{ github.actor }}"
           git add quality-metrics.json
           git commit --no-verify -m "chore: update quality metrics [skip ci]"
           git pull --rebase origin main
-          git push
+          # Use RELEASE_TOKEN for push so the commit can trigger downstream workflows
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $(echo -n "x-access-token:$RELEASE_TOKEN" | base64)" push
 
   # =============================================================================
   # SECURITY SCANNING PHASE
@@ -160,7 +162,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -190,6 +191,8 @@ jobs:
 
       - name: Commit version changes
         if: steps.version.outputs.changed == 'true'
+        env:
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           # Configure git with GitHub Actions bot identity
           git config --local user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
@@ -201,8 +204,8 @@ jobs:
           # Commit with [skip actions] to prevent workflow recursion
           git commit -m "chore(release): v${{ steps.version.outputs.version }} [skip actions]"
 
-          # Push changes to origin
-          git push origin main
+          # Push changes to origin using RELEASE_TOKEN so the commit can trigger downstream workflows
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $(echo -n "x-access-token:$RELEASE_TOKEN" | base64)" push origin main
 
           echo "✅ Version changes committed and pushed"
 
@@ -211,7 +214,7 @@ jobs:
         id: tag
         if: steps.version.outputs.changed == 'true'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
 
@@ -222,8 +225,8 @@ jobs:
           # Create annotated tag
           git tag -a "v${VERSION}" -m "Release v${VERSION}"
 
-          # Push tag to origin
-          git push origin "v${VERSION}"
+          # Push tag to origin using RELEASE_TOKEN
+          git -c http.https://github.com/.extraheader="AUTHORIZATION: basic $(echo -n "x-access-token:$RELEASE_TOKEN" | base64)" push origin "v${VERSION}"
 
           # Get the tag SHA for artifact naming
           TAG_SHA=$(git rev-list -n 1 "v${VERSION}")
@@ -456,7 +459,7 @@ jobs:
             dist-${{ needs.build.outputs.version }}-*.tar.gz
             dist-${{ needs.build.outputs.version }}-*.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
 
       - name: Set release output
         id: release

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,7 +83,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -160,7 +160,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Install pnpm
         uses: pnpm/action-setup@v4
@@ -456,7 +456,7 @@ jobs:
             dist-${{ needs.build.outputs.version }}-*.tar.gz
             dist-${{ needs.build.outputs.version }}-*.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set release output
         id: release


### PR DESCRIPTION
## Summary
- Checkout steps now use the default `GITHUB_TOKEN` (always valid) instead of `RELEASE_TOKEN`
- `RELEASE_TOKEN` is only used at push time via `git -c http.extraheader`, which is the only place elevated permissions are actually needed
- This prevents checkout failures when `RELEASE_TOKEN` is missing or expired

## Root cause
PR #169 changed `token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}` to `token: ${{ secrets.RELEASE_TOKEN }}` in checkout steps. When the token is invalid, `actions/checkout` fails with `fatal: could not read Username for 'https://github.com'`.

The fix isn't just restoring the fallback — it's separating concerns: checkout (read-only, always works with default token) from push (needs elevated token to trigger downstream workflows).

## Changes
| Location | Before | After |
|---|---|---|
| `build` checkout | `token: RELEASE_TOKEN` | default `GITHUB_TOKEN` |
| `update-metrics` checkout | `token: RELEASE_TOKEN` | default `GITHUB_TOKEN` |
| `build` push steps | inherited from checkout | `git -c extraheader` with `RELEASE_TOKEN` |
| `update-metrics` push | inherited from checkout | `git -c extraheader` with `RELEASE_TOKEN` |
| `create-release` env | unchanged | `RELEASE_TOKEN` (for GitHub Release API) |

## Test plan
- [ ] Verify checkout succeeds even when RELEASE_TOKEN is missing/invalid
- [ ] Verify push steps use RELEASE_TOKEN for elevated permissions
- [ ] Verify `check-token` pre-flight still gates jobs that need to push

🤖 Generated with [Claude Code](https://claude.com/claude-code)